### PR TITLE
Add missing attributes to `salesOrderInvoiceInfo` SOAP method

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Api.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Api.php
@@ -98,6 +98,9 @@ class Mage_Sales_Model_Order_Invoice_Api extends Mage_Sales_Model_Api_Resource
 
         $result = $this->_getAttributes($invoice, 'invoice');
         $result['order_increment_id'] = $invoice->getOrderIncrementId();
+        $result['order_created_at'] = $invoice->getOrder()->getCreatedAt();
+        $result['billing_firstname'] = $invoice->getBillingAddress()->getFirstname();
+        $result['billing_lastname'] = $invoice->getBillingAddress()->getLastname();
 
         $result['items'] = array();
         foreach ($invoice->getAllItems() as $item) {


### PR DESCRIPTION

### Description (*)
This PR will add 3 missing attributes to be returned in the `salesOrderInvoiceInfo` SOAP call:
- `order_created_at`
- `billing_firstname`
- `billing_lastname`

These attributes are mentioned in the official [Magento documentation](https://r-martins.github.io/m1docs/guides/m1x/api/soap/sales/salesOrderInvoice/sales_order_invoice.info.html) but are missing from the response.

### Manual testing scenarios (*)
1. Run the following code and you should see the above attributes after the change:
```php
$client = new SoapClient('<magento_host>/api/v2_soap/?wsdl');
$session = $client->login('<username>', '<password>');
var_dump($client->salesOrderInvoiceInfo($session, '<increment_id>');
```

### Questions or comments

I assumed the billing address will never be `null` so I didn't do any extra checks. Correct me if I'm wrong.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 